### PR TITLE
Update unxip.cpp

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,13 +4,13 @@ Since people have started using dash modifications again, and having issues with
 
 To use it; open a command prompt.
 
-```
+
 unxip.exe -extract [where-to-extract] [nameof.xip]
-```
+
 For example:
-```
+
 unxip.exe -extract [default] [default.xip]
-```
+
 Will extract the contents of default.xip to the default folder.
 
 I'll clean this up later and make it easier to use/more organized but for now its quite simple and straight forward as is.

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,26 @@
+Readme:
+
+Since people have started using dash modifications again, and having issues with XIP files I decided to make some slight changes to this wonderful tool.
+
+To use it; open a command prompt.
+
+```
+unxip.exe -extract [where-to-extract] [nameof.xip]
+```
+For example:
+```
+unxip.exe -extract [default] [default.xip]
+```
+Will extract the contents of default.xip to the default folder.
+
+I'll clean this up later and make it easier to use/more organized but for now its quite simple and straight forward as is.
+
+Special thanks to MaTiAz for his original sources, Voltaic for PIXIT which this is based on, and JayFoxRox from whom I forked this, as he added CMAKE in his original modification.
+
+
+
+Original Readme:
+
 UnXiP - by MaTiAz (modified by JayFoxRox)
 
 Based on PIXIT 0.5 sources by Voltaic.

--- a/unxip.cpp
+++ b/unxip.cpp
@@ -10,6 +10,9 @@
  * little dizzy for you, but its because im a C++ newbie(this
  * is my first Xbox related application on C++).
  *
+ * November 20, 2022 - Added extraction of meshes/models.
+ * Removed extraction of .ib and .vb files.
+ *
  ************************************************************/
 
 #ifndef _WIN32
@@ -31,7 +34,7 @@
 #include <stdint.h>
 
 #define UNXIP_MAJOR_VER	0
-#define UNXIP_MINOR_VER	1
+#define UNXIP_MINOR_VER	2
 
 typedef struct _tagXIPHDR
 {
@@ -261,7 +264,16 @@ int ExtractArchive(const char* pszExtractFolder, const char* pszArchiveFile)
 
 		const char* pszFilename = GetFilenameAt(pszFilenameBlock, n);
 
-		if(pData->nType == 4)
+		// nType == 5 .ib
+		// nType == 6 .vb
+		// These two filetypes are unescesarry.
+		// Removed nType == 4, as we want the XIP files to be extracted in full. Thus, we want XM (model/mesh) files.
+		if(pData->nType == 5)
+		{
+			printf("Skipping file '%s' ...\n", pszFilename);
+			continue;
+		}
+		if (pData->nType == 6)
 		{
 			printf("Skipping file '%s' ...\n", pszFilename);
 			continue;


### PR DESCRIPTION
Enabled extraction of XM models by changing nType, also added ignore .ib and .vb extraction. Most tools as well as modified dashboards don't rely on these files. No need to extract them.